### PR TITLE
Composer autoload fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"autoload": {
 		"psr-4": {
-			"Pays\\PaymentGate\\": "src/"
+			"Axima\\PaymentGate\\": "src/"
 		}
 	}
 }


### PR DESCRIPTION
Hi,
There's a problem with the autoloader. The class uses Axima\PaymentGate namespace while Pays\PaymentGate is defined in composer.json.